### PR TITLE
Run the docker-build workflow only on main branch changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,9 +6,6 @@ on:
       - main
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
Docker build does not need to be checked on each PR.