### PR TITLE
Derive authorities from user roles

### DIFF
--- a/src/main/java/com/penguineering/gartenplus/auth/GartenplusUser.java
+++ b/src/main/java/com/penguineering/gartenplus/auth/GartenplusUser.java
@@ -1,12 +1,16 @@
 package com.penguineering.gartenplus.auth;
 
+import com.penguineering.gartenplus.auth.role.SystemRole;
 import com.penguineering.gartenplus.auth.user.UserDTO;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class GartenplusUser implements OAuth2User {
     private final OAuth2User origin;
@@ -14,9 +18,13 @@ public class GartenplusUser implements OAuth2User {
     @Getter
     private final UserDTO user;
 
-    public GartenplusUser(OAuth2User origin, UserDTO user) {
+    @Getter
+    private final Set<SystemRole> roles;
+
+    public GartenplusUser(OAuth2User origin, UserDTO user, Set<SystemRole> roles) {
         this.origin = origin;
         this.user = user;
+        this.roles = roles;
     }
 
     @Override
@@ -26,7 +34,10 @@ public class GartenplusUser implements OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return origin.getAuthorities();
+        return roles.stream()
+                .map(SystemRole::asSpringRole)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/penguineering/gartenplus/auth/role/SystemRole.java
+++ b/src/main/java/com/penguineering/gartenplus/auth/role/SystemRole.java
@@ -15,4 +15,8 @@ public enum SystemRole {
         this.handle = handle;
         this.displayName = displayName;
     }
+
+    public final String asSpringRole() {
+        return "ROLE_" + handle.toUpperCase();
+    }
 }

--- a/src/main/java/com/penguineering/gartenplus/ui/appframe/LoggedUserView.java
+++ b/src/main/java/com/penguineering/gartenplus/ui/appframe/LoggedUserView.java
@@ -1,5 +1,6 @@
 package com.penguineering.gartenplus.ui.appframe;
 
+import com.penguineering.gartenplus.auth.role.SystemRole;
 import com.penguineering.gartenplus.auth.user.UserDTO;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.avatar.Avatar;
@@ -16,6 +17,8 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.net.URI;
 import java.util.Optional;
@@ -47,6 +50,11 @@ public class LoggedUserView extends Div {
                 .ifPresent(avatar::setImage);
 
 
+        // Check if the user has the ADMINISTRATOR role
+        boolean isAdmin = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(role -> role.equals(SystemRole.ADMINISTRATOR.asSpringRole()));
+
         // Set up the menu
         userMenu = new MenuBar();
         userMenu.addThemeVariants(MenuBarVariant.LUMO_ICON);
@@ -57,12 +65,19 @@ public class LoggedUserView extends Div {
 
         subMenu.addItem(createMenuItemWithIcon("Profil", VaadinIcon.USER),
                 e -> navigateTo("/admin/profile"));
+
         subMenu.addSeparator();
+
         subMenu.addItem(createMenuItemWithIcon("Dashboard", VaadinIcon.HOME),
                 e -> navigateTo("/"));
-        subMenu.addItem(createMenuItemWithIcon("Einstellungen", VaadinIcon.COG),
-                e -> navigateTo("/admin/settings"));
+
         subMenu.addSeparator();
+
+        if (isAdmin) {
+            subMenu.addItem(createMenuItemWithIcon("Einstellungen", VaadinIcon.COG),
+                    e -> navigateTo("/admin/settings"));
+        }
+
         subMenu.addItem(createMenuItemWithIcon("Abmelden", VaadinIcon.SIGN_OUT),
                 e -> navigateTo("/admin/logout"));
 

--- a/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/SettingsPage.java
+++ b/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/SettingsPage.java
@@ -5,10 +5,10 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 
 @Route(value = "", layout = SettingsLayout.class)
-@PermitAll
+@RolesAllowed("ADMINISTRATOR")
 @PageTitle("GartenPlus | Einstellungen")
 public class SettingsPage extends GartenplusPage implements BeforeEnterObserver {
     @Override

--- a/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/groups/GroupSettingsPage.java
+++ b/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/groups/GroupSettingsPage.java
@@ -9,7 +9,7 @@ import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -18,7 +18,7 @@ import java.util.UUID;
 import java.util.stream.StreamSupport;
 
 @Route(value = "groups", layout = SettingsLayout.class)
-@PermitAll
+@RolesAllowed("ADMINISTRATOR")
 @PageTitle("GartenPlus | Einstellungen | Gruppen")
 public class GroupSettingsPage extends GartenplusPage {
     private final GroupRepository groupRepository;

--- a/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/users/UsersSettingsPage.java
+++ b/src/main/java/com/penguineering/gartenplus/ui/content/admin/settings/users/UsersSettingsPage.java
@@ -11,14 +11,14 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
 @Route(value = "users", layout = SettingsLayout.class)
-@PermitAll
+@RolesAllowed("ADMINISTRATOR")
 @PageTitle("GartenPlus | Einstellungen | Benutzer")
 
 public class UsersSettingsPage extends GartenplusPage {


### PR DESCRIPTION
Load the user roles and convert them into authorities that can be used for authorization. Limit settings pages to administrators.