### PR TITLE
Give administrator rights when the role is not assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Configuration is done using environment variables:
 
 * `PORT`: Port for the HTTP endpoint (default `8080`, only change when running locally!)
+* `ASSIGN_ADMINISTRATOR_IF_MISSING`: Make everyone an Administrator if none is found in the database (default `false`)
 * `OAUTH_CALLBACK_BASE_URI`: Base URI for the OAuth callback (defaults to `http://localhost:8080`)
 * `GITHUB_OAUTH_CLIENT_ID`: GitHub OAuth Client ID (defaults to none and will disable GitHub authentication if not set)
 * `GITHUB_OAUTH_CLIENT_SECRET`: GitHub OAuth Client Secret (defaults to none and will disable GitHub authentication if not set)

--- a/src/main/java/com/penguineering/gartenplus/AutoAdministratorInitializer.java
+++ b/src/main/java/com/penguineering/gartenplus/AutoAdministratorInitializer.java
@@ -1,0 +1,44 @@
+// In AdminRoleInitializer.java
+
+package com.penguineering.gartenplus;
+
+import com.penguineering.gartenplus.auth.role.SystemRole;
+import com.penguineering.gartenplus.auth.role.SystemRoleService;
+import com.penguineering.gartenplus.auth.user.UserEntityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "gartenplus.security.auto-admin", havingValue = "true")
+public class AutoAdministratorInitializer {
+    private static final Logger logger = LoggerFactory.getLogger(AutoAdministratorInitializer.class);
+
+    private final UserEntityService userEntityService;
+    private final SystemRoleService systemRoleService;
+
+    public AutoAdministratorInitializer(UserEntityService userEntityService, SystemRoleService systemRoleService) {
+        this.userEntityService = userEntityService;
+        this.systemRoleService = systemRoleService;
+    }
+
+    @Bean
+    public CommandLineRunner checkAndGrantAdminRole() {
+        return args -> {
+            boolean hasAdmin = userEntityService.getAllUsers().stream()
+                    .anyMatch(user -> systemRoleService.getRolesForUser(user.id()).contains(SystemRole.ADMINISTRATOR));
+
+            if (!hasAdmin) {
+                logger.warn("AUTO-ADMIN: No administrator found, granting all users the administrator role");
+
+                userEntityService.getAllUsers().forEach(user -> 
+                    systemRoleService.setRoleForUser(SystemRole.ADMINISTRATOR, user.id())
+                );
+            } else
+                logger.info("AUTO-ADMIN: Administrator found, skipping role assignment");
+        };
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,3 +46,7 @@ spring:
             token-uri: https://github.com/login/oauth/access_token
             user-info-uri: https://api.github.com/user
             user-name-attribute: id
+
+gartenplus:
+  security:
+    auto-admin: ${ASSIGN_ADMINISTRATOR_IF_MISSING:false}


### PR DESCRIPTION
When configured, this solves the cold-start-problem of not having an administrator.