### PR TITLE
Bump spring-boot-starter-parent to 3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.penguineering</groupId>


### PR DESCRIPTION
There has been a vulnerability in Spring Boot that calls for an update.