### PR TITLE
Use the main branch cache in PR test runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,8 +38,10 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: ${{ runner.os }}-m2-${ github.ref }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-m2-${ github.ref }}
+          ${{ runner.os }}-m2-main
 
     - name: Run Maven Build
       run: mvn clean package -Pproduction

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -25,8 +25,10 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: ${{ runner.os }}-m2-${ github.ref }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-m2-${ github.ref }}
+          ${{ runner.os }}-m2-main
 
     - name: Run tests
       run: mvn --batch-mode --update-snapshots -Pproduction clean verify


### PR DESCRIPTION
This pull request includes updates to the caching strategy in the GitHub Actions workflows for building Docker images and running Maven tests to make use of the main branch's cache in PRs.